### PR TITLE
BRONTO-1667 initial version of Bronto MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+# IntelliJ
+.idea/
+*.iml
+
+# Emacs
+*~
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Build directories
+**/builds/*
+
+# HCL files. We might revisit this
+*.hcl
+
+# IntelliJ
+**/.idea/
+**/out/
+
+# MAc OS X
+.DS_Store
+
+# Pytest
+**/__pycache__/
+
+# Python virtual envs
+**/env/
+
+# Minikube
+**/minikube-darwin-arm64
+
+# zip files in Azure folder
+azure/**/*.zip

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# Bronto MCP Server
+
+This project contains a P.O.C MCP server for Bronto. 
+
+It currently provides 3 tools 
+
+- `get_logs`: retrieves log data based on a timerange and a list of log IDs
+- `get_datasets`: retrieves datasets details for the configured account
+- `get_timestamp_as_unix_epoch`: converts dates such as `2025-05-10 16:25:05` to a unix timestamp in milliseconds
+
+When these tools are provided to an AI agent, they make it possible to answer questions such as
+
+_Can you please provide some log events from datasets in the ingestion collection, except for the ones related to garbage collection? The data should be between "2025-05-10 16:05:45" and "2025-05-10 16:25:05"._
+
+
+## Installation
+
+Create a virtual environment at the root of the project and install the requirements, e.g.
+
+```shell
+python3 -m venv env
+env/bin/pip install -r requirements.txt
+```
+
+## Configuration
+
+This MCP server can be configured using environment variables:
+
+- `BRONTO_API_KEY`: a Bronto API key
+- `BRONTO_API_ENDPOINT`: a Bronto API endpoint, e.g. https://api.eu.staging.bronto.io
+
+
+## Usage
+
+This MCP server should work with any agent that supports MCP. However, it has only been tested with the Amazon Bedrock Client: https://github.com/aws-samples/amazon-bedrock-client-for-mac
+
+Note: if `~/.aws/config` is present on your system and `~/.aws/credentials` is not, AWS Bedrock client will show an error at startup and will not be able to connect to AWS.
+One way to overcome the issue is to create `~/.aws/credentials` and to add a profile to it. The profile definition can be obtained from IAM Identity Centre (Option 2 when selecting `Access Keys`, i.e. `Option 2: Add a profile to your AWS credentials file`)
+After restarting the Bedrock client,, you might need to select the profile to use in the Bedrock Client settings.
+
+Finally, in order to configure the client so that it uses the Bronto MCP server, first make sure that `Enable MCP` is selected, in the `Developer` section of the settings. Then select `Open Config File` and use a configuration similar to the following one:
+```json
+{ "mcpServers": {
+    "bronto": {
+        "command": "/PATH/TO/bronto-mcp-server/env/bin/python",
+        "args": [
+            "/PATH/TO/bronto-mcp-server/src/main/brmcpserver/main.py"
+        ],
+        "env": {
+            "PYTHONPATH": "/PATH/TO/bronto-mcp-server/src/main/brmcpserver/",
+            "BRONTO_API_KEY": "*******",
+            "BRONTO_API_ENDPOINT": "https://api.eu.staging.bronto.io"
+          }
+    }
+    }
+ }
+```
+
+Restarting the client will probably be needed at this point. After it restarts, the tools exposed by the MCP server 
+should be listed when clicking on the `+` sign at the bottom of the client window.
+
+You can test that the Bronto MCP server can be used by the client by asking a question such as:
+
+```
+Can you please provide some log events from datasets in the ingestion collection, except for the ones related to garbage collection? The data should be between "2025-05-10 16:05:45" and "2025-05-10 16:25:05".
+```
+
+The output should make it clear that the client is retrieving data from Bronto.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+mcp[cli]
+zstd

--- a/src/main/brmcpserver/clients.py
+++ b/src/main/brmcpserver/clients.py
@@ -1,0 +1,105 @@
+import time
+
+import zstd
+import urllib.request
+import logging
+import os
+import json
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+handler = logging.FileHandler('/tmp/bronto_mcp.log')
+handler.setLevel(logging.DEBUG)
+
+# Define the log message format
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+
+# Attach the handler to the logger
+logger.addHandler(handler)
+
+class BrontoClient:
+
+    def __init__(self, api_key, api_endpoint):
+        self.api_key = api_key
+        self.api_endpoint = api_endpoint
+        self.headers = {
+            'Content-Type': 'application/json',
+            'User-Agent': 'bronto-behaviour-comparison',
+            'x-bronto-api-key': self.api_key
+        }
+
+    def _create_export(self, timestamp_start: int, timestamp_end: int, log_ids: list[str]):
+        url_path = 'exports'
+        payload = json.dumps({'search_details':
+                                  {'from': ':'.join(log_ids), 'from_ts': timestamp_start, 'to_ts': timestamp_end,
+                                   'where': ''}
+                              }).encode()
+        endpoint = os.path.join(self.api_endpoint, url_path)
+        request = urllib.request.Request(endpoint, data=payload, headers=self.headers)
+        logger.info('Export creation. endpoint=%s, path=%s, payload=%s', endpoint, url_path, payload)
+        try:
+            with urllib.request.urlopen(request) as resp:
+                logger.info('Export creation status, status=%s',resp.status)
+                if resp.status != 200 and resp.status != 201:
+                    logger.error('Export creation failed, status=%s, reason=%s',resp.status, resp.reason)
+                    return None
+                result = json.loads(resp.read())
+                export_id = result.get('export_id')
+                logger.info('Export created successfully. export_id=%s', export_id)
+                return result
+        except Exception as e:
+            logger.error('ERROR creating export! endpoint=%s, path=%s, payload=%s', endpoint, url_path,
+                         payload, exc_info=e)
+
+    def retrieve_log_data(self, export_id, progress):
+        url_path = f'exports/{export_id}'
+        request = urllib.request.Request(os.path.join(self.api_endpoint, url_path), headers=self.headers)
+        max_attempts = 5
+        attempts = 0
+        wait_between_attempts_sec = 3
+        result = {}
+        while progress < 100 and attempts < max_attempts:
+            time.sleep(wait_between_attempts_sec)
+            attempts += 1
+            with urllib.request.urlopen(request) as resp:
+                logger.info('Export retrieval status, status=%s',resp.status)
+                if resp.status != 200 and resp.status != 201:
+                    logger.error('Export retrieval failed, status=%s, reason=%s',resp.status, resp.reason)
+                    continue
+                result = json.loads(resp.read())
+                progress = result.get('progress')
+                logger.info('Export retrieval progress, progress=%s',progress)
+        if progress == 100:
+            logger.info('Export completed successfully. export_id=%s', export_id)
+            s3_location = result.get('location')
+            with urllib.request.urlopen(s3_location) as resp:
+                if resp.status != 200 and resp.status != 201:
+                    logger.error('Data retrieval from S3 failed, status=%s, reason=%s, url=%s',resp.status,
+                                 resp.reason, s3_location)
+                    return
+                return resp.read()
+        return None
+
+    def get_log_data(self, timestamp_start: int, timestamp_end: int, log_ids: list[str]):
+        result = self._create_export(timestamp_start, timestamp_end, log_ids)
+        if result is None:
+            return None
+        export_id = result.get('export_id')
+        progress = result.get('progress')
+        compressed_data = self.retrieve_log_data(export_id, progress)
+        raw_data = zstd.decompress(compressed_data)
+        data = raw_data.decode()
+        return data
+
+    def get_datasets(self):
+        url_path = 'logs'
+        request = urllib.request.Request(os.path.join(self.api_endpoint, url_path), headers=self.headers)
+        with urllib.request.urlopen(request) as resp:
+            if resp.status != 200 and resp.status != 201:
+                logger.error('Dataset retrieval failed, status=%s, reason=%s',resp.status, resp.reason)
+            datasets = json.loads(resp.read()).get('logs', [])
+            logging.info('DATASETS=%s', datasets)
+            return datasets

--- a/src/main/brmcpserver/config.py
+++ b/src/main/brmcpserver/config.py
@@ -1,0 +1,7 @@
+import os
+
+class Config:
+
+    def __init__(self):
+        self.bronto_api_key = os.environ.get('BRONTO_API_KEY', '09871117-bbe6-44d4-9ea0-4270ad6fecd2.U9ueIDEpGbUVe8kVyVOupUQ0Fo8K958hvihuVTbVFhU=')
+        self.bronto_api_endpoint = os.environ.get('BRONTO_API_ENDPOINT', 'https://api.eu.staging.bronto.io')

--- a/src/main/brmcpserver/main.py
+++ b/src/main/brmcpserver/main.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+import logging
+
+from mcp.server.fastmcp import FastMCP
+from config import Config
+from clients import BrontoClient
+
+# Create an MCP server
+mcp = FastMCP("Bronto Search")
+
+logger = logging.getLogger()
+# TODO: debugging issues is not easy. We try to get some visibility by logging to a file
+# even this is proving difficult sometime. Logging an error as part of an exception being raised seems to always
+# generate logs though.
+handler = logging.FileHandler('/tmp/bronto_mcp.log')
+handler.setLevel(logging.DEBUG)
+
+# Define the log message format
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+
+# Attach the handler to the logger
+logger.addHandler(handler)
+
+@mcp.tool()
+def get_logs(timerange_start: int, timerange_end: int, log_ids: list[str]) -> list[str]:
+    """Fetches log data. This tool returns a list of log events
+    The prompt should be a question or statement that you want for log data to be retrieved,
+    such as "Can you please retrieve some log data from datasets related to the Bronto ingestion system?".
+    Only the raw data should be presented to the user. No summary or other details should be presented to them.
+    timerange_start and timerange_end are Python integer, not floats.
+    log IDs must be provided as a Python list of strings. Each string represents a UUID.
+    """
+    logger.info('timerange_start=%s, timerange_end=%s, log_ids=%s', timerange_start, timerange_end, log_ids)
+    try:
+        config = Config()
+        bronto_client = BrontoClient(config.bronto_api_key, config.bronto_api_endpoint)
+        result = bronto_client.get_log_data(timerange_start, timerange_end, log_ids)
+        return result.split('\r\n')[:100]
+    except Exception as e:
+        logger.error('Exception! exception=%s', e, exc_info=e)
+        return ["Error."]
+
+@mcp.tool()
+def get_timestamp_as_unix_epoch(input_time: str) -> int:
+    """Provides a unix timestamp (in milliseconds) since epoch representation of the input time. This tool
+    takes 1 string as parameters, representing a time in the following format '%Y-%m-%d %H:%M:%S'. For instance with
+    input_time='2025-05-01-00 00:00:00' then this tool returns 1746054000000. And with input_time='2025-05-01 01:00:00',
+    then this tool returns 1746057600000)
+    """
+    return int(datetime.strptime(input_time, '%Y-%m-%d %H:%M:%S').timestamp()) * 1000
+
+
+@mcp.tool()
+def get_datasets() -> list[str]:
+    """Fetches all dataset details. This tool returns a list strings. Each string provides
+    - the name of the dataset
+    - the collection it belongs to
+    - its log ID, which is a UUID, i.e. a 36 character long string
+    - a list of tags associated to the dataset. Each tag is a key-value pair. The key and the value are separated with an equal
+    sign, i.e. the "=" character and the values are quoted with double quotes.
+    """
+    config = Config()
+    bronto_client = BrontoClient(config.bronto_api_key, config.bronto_api_endpoint)
+    datasets = bronto_client.get_datasets()
+    result = []
+    for dataset in datasets:
+        tags_sub_sentence = 'has no tags'
+        if len(dataset["tags"]) > 0:
+            tags_sub_sentence = 'has the following tags: ' + ', '.join([f'{tag}="{dataset["tags"][tag]}' for tag in dataset["tags"]])
+        result.append(f'Dataset with name {dataset["log"]}, in collection {dataset["logset"]} and log ID {dataset["log_id"]} {tags_sub_sentence}')
+    return result
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
Down the line, we'll probably want to rely on library regarding ways to express time in plain english. 

Also having a Bronto python client may be a good idea (maybe we can autogenerate one with some tool, from our openapi spec).

This is just a P.O.C. We can change anything there. For instance, log data retrieval is currently done using `export`. This is to accommodate a use case that I wanted to test but moved away from.