### PR TITLE
BRONTO-1812 refactor + add unit tests + improve error handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 mcp[cli]
 zstd
+
+pytest

--- a/src/main/brmcpserver/main.py
+++ b/src/main/brmcpserver/main.py
@@ -1,15 +1,10 @@
 import logging
 import sys
-import time
 
-from pydantic import Field, BeforeValidator
-from typing_extensions import Annotated
-from datetime import datetime, timezone
-from typing import List, Optional
 from mcp.server.fastmcp import FastMCP
 from config import Config
 from clients import BrontoClient
-from models import Dataset, DatasetKey, LogEvent, Datapoint, Timeseries
+from tools import BrontoTools
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -17,212 +12,22 @@ handler = logging.StreamHandler(sys.stdout)
 handler.setLevel(logging.DEBUG)
 logger.addHandler(handler)
 
-# Create an MCP server
-mcp = FastMCP("Bronto", stateless_http=True, streamable_http_path="/", json_response=True)
-
-
-@mcp.tool(description="""Searches log data. This tool returns a list of log events and their attributes
-    The prompt should be a question or statement that you want for log data to be searched,
-    such as "Can you please search some log data from datasets related to the Bronto ingestion system?".
-    Only the @raw field should be presented to the user. No summary or other details should be presented to them.
-    """)
-def search_logs(
-        timerange_start: Annotated[Optional[int], Field(
-            description='Unix timestamp in millisecond representing the start of a time range, e.g. 1756063146000. '
-                        'If not specify, the current time is selected',
-            default_factory=lambda _: (int(time.time()) - (20 * 60)) * 1000
-        )],
-        timerange_end: Annotated[Optional[int], Field(
-            description='Unix timestamp in millisecond representing the end of a time range, e.g. 1756063254000. '
-                        'If not specify, the time from 20 minutes ago is selected',
-            default_factory=lambda _: int(time.time()) * 1000
-        )],
-        log_ids: Annotated[list[str], Field(description='List of dataset IDs, identifying sets of log data. Each log ID '
-                                                        'represents a UUID', min_length=1)],
-        search_filter: Annotated[
-            Optional[str],
-            Field(default='', description="""
-            If no value is specified for this field, then no filter is apply when searching log data. Otherwise, 
-            this field must follow the syntax of an SQL `WHERE` clause. Unless the search filter is 
-            explicitly provided by the user, it is CRITICAL to use keys present in the dataset, e.g. 
-            "key_name"='key_value'. For this, the list of keys present in dataset can be retrieved via another tool 
-            exposed by this MCP server. In any case, following SQL syntax,
-                - key names should be double-quoted
-                - key value should be single-quoted if they are expected to be strings of characters
-                - key value should not be quoted if they are expected to be numbers."""
-        )],
-    ) -> Annotated[
-        List[LogEvent],
-        Field(description='A list of log events and their attributes. Attributes are key-value pairs associated with '
-                          'the event, e.g. key=value')
-    ]:
-    logger.info('timerange_start=%s, timerange_end=%s, log_ids=%s', timerange_start, timerange_end, log_ids)
-    try:
-        config = Config()
-        bronto_client = BrontoClient(config.bronto_api_key, config.bronto_api_endpoint)
-        log_events = bronto_client.search(timerange_start, timerange_end, log_ids, search_filter, _select=['*', '@raw'])
-        return log_events
-    except Exception as e:
-        raise Exception('Exception! exception=%s', e)
-
-
-@mcp.tool(description="""Computes metric data from log data. This tool returns a list of data points for each key in the group_by_keys
-    list. Each list represents the value of the computed metrics for a subset of the provided time range.
-
-    The prompt should be a question or statement that you want for a metric to be computed. For instance for web access
-    or CDN logs, the question could look like the following: "Can you please provide the sum of the average response
-    time per path for the last hour?". The answer would then return the AVG(response_time) metric, grouped by URL path,
-    and split into a list of data points, one per every 5 minutes of the provided time range.
-    """)
-def compute_metrics(
-        timerange_start: Annotated[int, Field(
-            description='Unix timestamp in millisecond representing the start of a time range, e.g. 1756063146000',
-            default_factory=lambda _: int(time.time()) * 1000
-        )],
-        timerange_end: Annotated[int, Field(
-            description='Unix timestamp in millisecond representing the end of a time range, e.g. 1756063254000',
-            default_factory=lambda _: (int(time.time()) - (20 * 60)) * 1000
-        )],
-        log_ids: Annotated[list[str], Field(description='List of dataset IDs, identifying sets of log data. Each log ID '
-                                                        'represents a UUID', min_length=1)],
-        metric_functions: Annotated[list[str], Field(description='''
-            The metric function can be one of AVG, MIN, MAX, COUNT, MEAN, MEDIAN and SUM. The metric function takes a 
-            key name as attribute, except for COUNT which only takes the character '*' as attribute. Key names can be 
-            determined for given datasets, using one of the other tools provided by this MCP server.''')],
-        search_filter: Annotated[str, Field(description="""
-            The `search_filter` attribute can follow the syntax of an SQL `WHERE` clause. Unless the search filter is 
-            explicitly provided by the user, it is CRITICAL to use keys present in the dataset, e.g. 
-            "key_name"='key_value'. For this, the list of keys present in dataset can be retrieved via another tool 
-            exposed by this MCP server. In any case, following SQL syntax,
-                - key names should be double-quoted
-                - key value should be single-quoted if they are expected to be strings of characters
-                - key value should not be quoted if they are expected to be numbers."""
-            )] = '',
-        group_by_keys: Annotated[List[str], Field(description='List of keys expected to be present in log datasets and '
-                                                              'by which the metric computed should be grouped')] = None
-    ) -> Annotated[
-        Timeseries,
-        Field(description='Timeseries containing a list of data points for each key in the group_by_keys list. Each list '
-                          'represents the value of the computed metrics for a subset of the provided time range')
-    ]:
-    if group_by_keys is None:
-        group_by_keys = []
-    logger.info('timerange_start=%s, timerange_end=%s, log_ids=%s, metric_functions=%s, group_by_keys=[%s]',
-                timerange_start, timerange_end, log_ids, ','.join(metric_functions), ','.join(group_by_keys))
-    try:
-        config = Config()
-        bronto_client = BrontoClient(config.bronto_api_key, config.bronto_api_endpoint)
-        resp = bronto_client.search_post(timerange_start, timerange_end, log_ids, search_filter,
-                                           _select=metric_functions)
-        totals = resp['totals']
-        timeseries = []
-        for datapoint in totals.get('timeseries', []):
-            timeseries.append(Datapoint(timestamp=datapoint['@timestamp'], count=datapoint['count'],
-                                        quantiles=datapoint['quantiles'], value=datapoint['value']))
-        return Timeseries(count=totals['count'], timeseries=timeseries)
-    except Exception as e:
-        logger.error('Exception! exception=%s', e, exc_info=e)
-        raise e
-
-
-def _validate_input_time(input_time: str) -> str:
-    try:
-        datetime.strptime(input_time, '%Y-%m-%d %H:%M:%S')
-        return input_time
-    except ValueError as e:
-        raise e
-
-
-@mcp.tool(description="""Provides a unix timestamp (in milliseconds) since epoch representation of the input time. This tool
-    takes 1 string as parameters, representing a time in the following format '%Y-%m-%d %H:%M:%S'. For instance with
-    input_time='2025-05-01 00:00:00' then this tool returns 1746054000000. And with input_time='2025-05-01 01:00:00',
-    then this tool returns 1746057600000
-    """)
-def get_timestamp_as_unix_epoch(
-        input_time: Annotated[
-            str,
-            BeforeValidator(_validate_input_time),
-            Field(description='Time represented in the "%Y-%m-%d %H:%M:%S" format')]
-    ) -> Annotated[
-        int,
-        Field(description='A unix timestamp (in milliseconds) since epoch, representing the `input_time` parameter')
-    ]:
-    return int(datetime.strptime(input_time, '%Y-%m-%d %H:%M:%S').astimezone(timezone.utc).timestamp()) * 1000
-
-
-@mcp.tool(description='Fetches all dataset details')
-def get_datasets() -> Annotated[
-        List[Dataset],
-        Field(description='''List of datasets. Each dataset object contains
-            - the name of the dataset
-            - the collection it belongs to
-            - its log ID, which is a UUID, i.e. a 36 character long string
-            - a list of tags associated to the dataset. Each tag is a key-value pair. Both keys and values are 
-            represented as strings. Tags such as the `description` tag are particularly useful to understand the type 
-            of data that the dataset contains. Other common tags are `service`, `teams` and `environment`''')
-    ]:
-    config = Config()
-    bronto_client = BrontoClient(config.bronto_api_key, config.bronto_api_endpoint)
-    datasets_data = bronto_client.get_datasets()
-    result = []
-    for dataset in datasets_data:
-        result.append(Dataset(name=dataset["log"], collection=dataset["logset"], log_id=dataset["log_id"],
-                              tags=dataset["tags"]))
-    return result
-
-
-@mcp.tool(description="""Fetches details about a Bronto dataset. A dataset is uniquely identify by its name and its 
-    collection name. In other words, several datasets with the same name can be associated with different collections. 
-    However only one dataset with a given name can be associated to a given collection.
-    """)
-def get_datasets_by_name(
-        dataset_name: Annotated[str, Field(description="The dataset name", min_length=1)],
-        collection_name: Annotated[str, Field(description="The collection that the dataset is part of", min_length=1)]
-    ) -> Annotated[
-        List[Dataset],
-        Field(description='List of datasets whose name and collection match the ones provided with the `dataset_name` '
-                          'and `collection_name` parameters. Details contains for instance the dataset log ID as well '
-                          'as all the tags associated to this dataset.')
-    ]:
-    config = Config()
-    bronto_client = BrontoClient(config.bronto_api_key, config.bronto_api_endpoint)
-    datasets = bronto_client.get_datasets()
-    result = []
-    collection_names = [dataset['logset'] for dataset in datasets]
-    if len(collection_names) == 0:
-        return []
-    for dataset in datasets:
-        if dataset['log'] != dataset_name or dataset['logset'] != collection_name:
-            continue
-        result.append(Dataset(name=dataset["log"], collection=dataset["logset"], log_id=dataset["log_id"],
-                              tags=dataset["tags"]))
-    if len(result) == 0:
-        return []
-    return result
-
-
-@mcp.tool(description="""Fetches all keys present in a dataset, which is represented by a log ID.
-    This tool takes a log ID as parameter. A log ID is a string representing a UUID. A log ID maps to a dataset and
-    collection name. So given a dataset and collection name, it is possible to retrieve its log ID by using another tool
-    which provides details on datasets.
-    This tool returns a list strings. Each string provides the name of a key present in the provided dataset
-    """)
-def get_keys(
-        log_id: Annotated[str, Field(description='The dataset ID, also named log ID', min_length=36, max_length=36)]
-    ) -> Annotated[
-        List[DatasetKey],
-        Field(description='list key names for keys present in the provided dataset referenced with the `log_id` parameter')
-    ]:
-    config = Config()
-    bronto_client = BrontoClient(config.bronto_api_key, config.bronto_api_endpoint)
-    keys = bronto_client.get_keys(log_id)
-    return keys
-
-@mcp.tool(description="This tool provides the current time in the YYYY-MM-DD HH:mm:ss format")
-def get_current_time() -> Annotated[str, Field(description='the current time in the YYYY-MM-DD HH:mm:ss format')]:
-    return datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S')
-
 
 if __name__ == "__main__":
     logger.info('Starting Bronto MCP server')
+    mcp = FastMCP(
+        "Bronto",
+        stateless_http=True,
+        streamable_http_path="/",
+        json_response=True,
+        instructions='Use this MCP server to interact with log data stored in Bronto as well as its metadata, datasets, '
+                     'collections, keys, etc',
+        dependencies=['pydantic', 'zstd']
+    )
+    config = Config()
+    bronto_client = BrontoClient(config.bronto_api_key, config.bronto_api_endpoint)
+    bronto_tools = BrontoTools(bronto_client)
+    bronto_tools.register(mcp)
+    logger.info('Bronto tools registered successfully')
+
     mcp.run(transport="streamable-http")

--- a/src/main/brmcpserver/tools.py
+++ b/src/main/brmcpserver/tools.py
@@ -1,0 +1,249 @@
+import time
+import logging
+
+from pydantic import Field, BeforeValidator
+from typing_extensions import Annotated
+from datetime import datetime, timezone
+from typing import List, Optional, Dict
+from models import Dataset, DatasetKey, LogEvent, Datapoint, Timeseries
+
+from clients import BrontoClient
+
+logger = logging.getLogger()
+
+
+class BrontoTools:
+    """Tools to interact with log data stored in Bronto"""
+
+    def __init__(self, bronto_client: BrontoClient):
+        self.bronto_client = bronto_client
+
+    def register(self, mcp):
+        mcp.tool(
+            name='search_logs',
+            description="""Searches log data. This tool returns a list of log events and their attributes
+                The prompt should be a question or statement that you want for log data to be searched,
+                such as "Can you please search some log data from datasets related to the Bronto ingestion system?".
+                Only the @raw field should be presented to the user. No summary or other details should be presented to them.
+                """
+        )(self.search_logs)
+
+        mcp.tool(
+            name='compute_metrics',
+            description="""Computes metric data from log data. This tool returns a list of data points for each key in the group_by_keys
+                list. Each list represents the value of the computed metrics for a subset of the provided time range.
+            
+                The prompt should be a question or statement that you want for a metric to be computed. For instance for web access
+                or CDN logs, the question could look like the following: "Can you please provide the sum of the average response
+                time per path for the last hour?". The answer would then return the AVG(response_time) metric, grouped by URL path,
+                and split into a list of data points, one per every 5 minutes of the provided time range.
+                """
+        )(self.compute_metrics)
+
+        mcp.tool(
+            name='get_timestamp_as_unix_epoch',
+            description="""Provides a unix timestamp (in milliseconds) since epoch representation of the input time. This tool
+                takes 1 string as parameters, representing a time in the following format '%Y-%m-%d %H:%M:%S'. For instance with
+                input_time='2025-05-01 00:00:00' then this tool returns 1746054000000. And with input_time='2025-05-01 01:00:00',
+                then this tool returns 1746057600000
+                """
+        )(self.get_timestamp_as_unix_epoch)
+
+        mcp.tool(
+            name='get_datasets',
+            description='Fetches all dataset details'
+        )(self.get_datasets)
+
+        mcp.tool(
+            name='get_datasets_by_name',
+            description="""Fetches details about a Bronto dataset. A dataset is uniquely identify by its name and its 
+                collection name. In other words, several datasets with the same name can be associated with different collections. 
+                However only one dataset with a given name can be associated to a given collection.
+                """
+        )(self.get_datasets_by_name)
+
+        mcp.tool(
+            name='get_keys',
+            description="""Fetches all keys present in a dataset, which is represented by a log ID.
+                This tool takes a log ID as parameter. A log ID is a string representing a UUID. A log ID maps to a dataset and
+                collection name. So given a dataset and collection name, it is possible to retrieve its log ID by using another tool
+                which provides details on datasets.
+                This tool returns a list strings. Each string provides the name of a key present in the provided dataset
+                """
+        )(self.get_keys)
+
+        mcp.tool(
+            name='get_current_time',
+            description="This tool provides the current time in the YYYY-MM-DD HH:mm:ss format"
+        )(self.get_current_time)
+
+    def search_logs(
+            self,
+            timerange_start: Annotated[Optional[int], Field(
+                description='Unix timestamp in millisecond representing the start of a time range, e.g. 1756063146000. '
+                            'If not specify, the current time is selected',
+                default_factory=lambda _: (int(time.time()) - (20 * 60)) * 1000
+            )],
+            timerange_end: Annotated[Optional[int], Field(
+                description='Unix timestamp in millisecond representing the end of a time range, e.g. 1756063254000. '
+                            'If not specify, the time from 20 minutes ago is selected',
+                default_factory=lambda _: int(time.time()) * 1000
+            )],
+            log_ids: Annotated[list[str], Field(description='List of dataset IDs, identifying sets of log data. Each log ID '
+                                                            'represents a UUID', min_length=1)],
+            search_filter: Annotated[
+                Optional[str],
+                Field(default='', description="""
+                If no value is specified for this field, then no filter is apply when searching log data. Otherwise, 
+                this field must follow the syntax of an SQL `WHERE` clause. Unless the search filter is 
+                explicitly provided by the user, it is CRITICAL to use keys present in the dataset, e.g. 
+                "key_name"='key_value'. For this, the list of keys present in dataset can be retrieved via another tool 
+                exposed by this MCP server. In any case, following SQL syntax,
+                    - key names should be double-quoted
+                    - key value should be single-quoted if they are expected to be strings of characters
+                    - key value should not be quoted if they are expected to be numbers."""
+                      )] = '',
+    ) -> Annotated[
+        List[LogEvent],
+        Field(description='A list of log events and their attributes. Attributes are key-value pairs associated with '
+                          'the event, e.g. key=value')
+    ]:
+        logger.info('timerange_start=%s, timerange_end=%s, log_ids=%s', timerange_start, timerange_end, log_ids)
+        log_events = self.bronto_client.search(timerange_start, timerange_end, log_ids, search_filter, _select=['*', '@raw'])
+        return log_events
+
+    def compute_metrics(
+            self,
+            timerange_start: Annotated[int, Field(
+                description='Unix timestamp in millisecond representing the start of a time range, e.g. 1756063146000',
+                default_factory=lambda _: (int(time.time()) - (20 * 60)) * 1000
+            )],
+            timerange_end: Annotated[int, Field(
+                description='Unix timestamp in millisecond representing the end of a time range, e.g. 1756063254000',
+                default_factory=lambda _: int(time.time()) * 1000
+            )],
+            log_ids: Annotated[list[str], Field(description='List of dataset IDs, identifying sets of log data. Each log ID '
+                                                            'represents a UUID', min_length=1)],
+            metric_functions: Annotated[list[str], Field(description='''
+                The metric function can be one of AVG, MIN, MAX, COUNT, MEAN, MEDIAN and SUM. The metric function takes a 
+                key name as attribute, except for COUNT which only takes the character '*' as attribute (i.e. 
+                "COUNT(*)"). Key names can be determined for given datasets, using one of the other tools provided by 
+                this MCP server.''')],
+            search_filter: Annotated[str, Field(description="""
+                The `search_filter` attribute can follow the syntax of an SQL `WHERE` clause. Unless the search filter is 
+                explicitly provided by the user, it is CRITICAL to use keys present in the dataset, e.g. 
+                "key_name"='key_value'. For this, the list of keys present in dataset can be retrieved via another tool 
+                exposed by this MCP server. In any case, following SQL syntax,
+                    - key names should be double-quoted
+                    - key value should be single-quoted if they are expected to be strings of characters
+                    - key value should not be quoted if they are expected to be numbers."""
+                                                )] = '',
+            group_by_keys: Annotated[List[str], Field(description='List of keys expected to be present in log datasets and '
+                                                                  'by which the metric computed should be grouped')] = None
+    ) -> Annotated[
+        Dict[str, Timeseries],
+        Field(description='Map of Timeseries. The keys of the map represent group names based on the group_by_keys '
+                          'parameter. The Timeseries represent a list of data points for the given group. Each list '
+                          'represents the value of the computed metrics for a subset of the provided time range')
+    ]:
+        if group_by_keys is None:
+            group_by_keys = []
+        logger.info('timerange_start=%s, timerange_end=%s, log_ids=%s, metric_functions=%s, group_by_keys=[%s]',
+                    timerange_start, timerange_end, log_ids, ','.join(metric_functions), ','.join(group_by_keys))
+        resp = self.bronto_client.search_post(timerange_start, timerange_end, log_ids, search_filter,
+                                              _select=metric_functions, group_by_keys=[','.join(group_by_keys)])
+        if len(group_by_keys) == 0:
+            totals = resp['totals']
+            count = totals['count']
+            timeseries = totals.get('timeseries', [])
+            name = ''
+            group_series = [{'name': name, 'timeseries':timeseries, 'count': count}]
+        else:
+            group_series = resp.get('groups_series', [])
+        result = {}
+        for group_serie in group_series:
+            datapoints = []
+            for datapoint in group_serie.get('timeseries', []):
+                datapoints.append(Datapoint(timestamp=datapoint['@timestamp'], count=datapoint['count'],
+                                            quantiles=datapoint['quantiles'], value=datapoint['value']))
+            timeseries = Timeseries(count=group_serie['count'], timeseries=datapoints)
+            result[group_serie['name']] = timeseries
+        return result
+
+    @staticmethod
+    def _validate_input_time(input_time: str) -> str:
+        try:
+            datetime.strptime(input_time, '%Y-%m-%d %H:%M:%S')
+            return input_time
+        except ValueError as e:
+            raise e
+
+    @staticmethod
+    def get_timestamp_as_unix_epoch(
+            input_time: Annotated[
+                str,
+                BeforeValidator(_validate_input_time),
+                Field(description='Time represented in the "%Y-%m-%d %H:%M:%S" format')]
+    ) -> Annotated[
+        int,
+        Field(description='A unix timestamp (in milliseconds) since epoch, representing the `input_time` parameter')
+    ]:
+        return int(datetime.strptime(input_time, '%Y-%m-%d %H:%M:%S').astimezone(timezone.utc).timestamp()) * 1000
+
+
+    def get_datasets(self) -> Annotated[
+        List[Dataset],
+        Field(description='''List of datasets. Each dataset object contains
+                - the name of the dataset
+                - the collection it belongs to
+                - its log ID, which is a UUID, i.e. a 36 character long string
+                - a list of tags associated to the dataset. Each tag is a key-value pair. Both keys and values are 
+                represented as strings. Tags such as the `description` tag are particularly useful to understand the type 
+                of data that the dataset contains. Other common tags are `service`, `teams` and `environment`''')
+    ]:
+        datasets_data = self.bronto_client.get_datasets()
+        result = []
+        for dataset in datasets_data:
+            result.append(Dataset(name=dataset["log"], collection=dataset["logset"], log_id=dataset["log_id"],
+                                  tags=dataset["tags"]))
+        return result
+
+
+    def get_datasets_by_name(
+            self,
+            dataset_name: Annotated[str, Field(description="The dataset name", min_length=1)],
+            collection_name: Annotated[str, Field(description="The collection that the dataset is part of", min_length=1)]
+    ) -> Annotated[
+        List[Dataset],
+        Field(description='List of datasets whose name and collection match the ones provided with the `dataset_name` '
+                          'and `collection_name` parameters. Details contains for instance the dataset log ID as well '
+                          'as all the tags associated to this dataset.')
+    ]:
+        datasets = self.bronto_client.get_datasets()
+        result = []
+        collection_names = [dataset['logset'] for dataset in datasets]
+        if len(collection_names) == 0:
+            return []
+        for dataset in datasets:
+            if dataset['log'] != dataset_name or dataset['logset'] != collection_name:
+                continue
+            result.append(Dataset(name=dataset["log"], collection=dataset["logset"], log_id=dataset["log_id"],
+                                  tags=dataset["tags"]))
+        if len(result) == 0:
+            return []
+        return result
+
+
+    def get_keys(
+            self,
+            log_id: Annotated[str, Field(description='The dataset ID, also named log ID', min_length=36, max_length=36)]
+    ) -> Annotated[
+        List[DatasetKey],
+        Field(description='list key names for keys present in the provided dataset referenced with the `log_id` parameter')
+    ]:
+        keys = self.bronto_client.get_keys(log_id)
+        return keys
+
+    @staticmethod
+    def get_current_time() -> Annotated[str, Field(description='the current time in the YYYY-MM-DD HH:mm:ss format')]:
+        return datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S')

--- a/src/tests/test_bronto_tools.py
+++ b/src/tests/test_bronto_tools.py
@@ -1,0 +1,168 @@
+import pytest
+import time
+from datetime import datetime
+from unittest.mock import Mock
+
+from tools import BrontoTools
+from models import Datapoint, Timeseries, DatasetKey, LogEvent
+from clients import BrontoClient
+
+
+@pytest.fixture
+def mock_bronto_client(monkeypatch):
+    client_mock = Mock(spec=BrontoClient)
+    return client_mock
+
+
+@pytest.fixture
+def bronto_tools(mock_bronto_client):
+    return BrontoTools(mock_bronto_client)
+
+
+def test_get_current_time():
+    current_time = BrontoTools.get_current_time()
+    assert isinstance(current_time, str)
+    datetime.strptime(current_time, '%Y-%m-%d %H:%M:%S')
+
+
+def test_get_timestamp_as_unix_epoch():
+    test_time = '2025-05-01 00:00:00'
+    timestamp = BrontoTools.get_timestamp_as_unix_epoch(test_time)
+    assert isinstance(timestamp, int)
+    assert timestamp == 1746054000000
+
+
+def test_get_timestamp_as_unix_epoch_wrong_format():
+    test_time = '2025/05/01 00:00:00'
+    with pytest.raises(ValueError):
+        BrontoTools.get_timestamp_as_unix_epoch(test_time)
+
+
+def test_get_datasets(bronto_tools, mock_bronto_client):
+    mock_datasets = [
+        {"log": "test_dataset", "logset": "test_collection", "log_id": "test_log_id", "tags": {"team": "test_team"}}
+    ]
+    mock_bronto_client.get_datasets.return_value = mock_datasets
+    datasets = bronto_tools.get_datasets()
+    assert len(datasets) == 1
+    assert datasets[0].name == "test_dataset"
+    assert datasets[0].collection == "test_collection"
+    assert datasets[0].log_id == "test_log_id"
+    assert datasets[0].tags == {"team": "test_team"}
+
+
+def test_get_datasets_by_name(bronto_tools, mock_bronto_client):
+    mock_datasets = [
+        {"log": "test_dataset", "logset": "test_collection", "log_id": "test_log_id", "tags": {"team": "test_team"}}
+    ]
+    mock_bronto_client.get_datasets.return_value = mock_datasets
+    datasets = bronto_tools.get_datasets_by_name("test_dataset", "test_collection")
+    assert len(datasets) == 1
+    assert datasets[0].name == "test_dataset"
+
+
+def test_get_datasets_by_name_no_match(bronto_tools, mock_bronto_client):
+    mock_datasets = [
+        {"log": "other_dataset", "logset": "other_collection", "log_id": "other_log_id", "tags": {}}
+    ]
+    mock_bronto_client.get_datasets.return_value = mock_datasets
+    datasets = bronto_tools.get_datasets_by_name("test_dataset", "test_collection")
+    assert len(datasets) == 0
+
+
+def test_get_keys(monkeypatch):
+    bronto_client = BrontoClient('some_api_key', 'some_endpoint')
+    monkeypatch.setattr(BrontoClient, 'get_top_keys', lambda _, __: {'key1': ['value1', '1']})
+    monkeypatch.setattr(BrontoClient, 'get_recent_keys', lambda _, __: {'key2': ['value2', '2']})
+    bronto_tools = BrontoTools(bronto_client)
+    keys = bronto_tools.get_keys("test_log_id")
+    assert len(keys) == 2
+    assert DatasetKey(name='key1', values=['value1', '1']) in keys
+    assert DatasetKey(name='key2', values=['value2', '2']) in keys
+
+
+def test_search_logs(bronto_tools, mock_bronto_client):
+    log_event1 = LogEvent(message="test_event1", attributes={'key1': 'value1'})
+    log_event2 = LogEvent(message="test_event2", attributes={'key2': 'value2'})
+    mock_log_events = [log_event1, log_event2]
+    mock_bronto_client.search.return_value = mock_log_events
+
+    log_events = bronto_tools.search_logs(
+        log_ids=["test_log_id"],
+        timerange_start=int(time.time()) * 1000,
+        timerange_end=int(time.time()) * 1000
+    )
+
+    assert len(log_events) == 2
+    assert log_event1 in log_events
+    assert log_event2 in log_events
+
+
+def test_compute_metrics_no_group(bronto_tools, mock_bronto_client):
+    timestamp = BrontoTools.get_timestamp_as_unix_epoch('2023-01-01 00:00:00')
+    mock_response = {
+        'totals': {
+            'count': 100,
+            'timeseries': [
+                {
+                    '@timestamp': timestamp,
+                    'count': 50,
+                    'quantiles': {},
+                    'value': 10.5
+                }
+            ]
+        }
+    }
+    mock_bronto_client.search_post.return_value = mock_response
+
+    metrics = bronto_tools.compute_metrics(
+        log_ids=["test_log_id"],
+        metric_functions=["SUM"],
+        timerange_start=int(time.time()) * 1000,
+        timerange_end=int(time.time()) * 1000
+    )
+
+    groups = list(metrics.keys())
+    assert len(groups) == 1
+    assert groups[0] == ''
+    group = metrics[groups[0]]
+    assert isinstance(group, Timeseries)
+    assert group.count == 100
+    assert len(group.timeseries) == 1
+    assert group.timeseries[0] == Datapoint(timestamp=timestamp, count=50, quantiles={}, value=10.5)
+
+
+def test_compute_metrics_single_group(bronto_tools, mock_bronto_client):
+    timestamp = BrontoTools.get_timestamp_as_unix_epoch('2023-01-01 00:00:00')
+    mock_response = {
+        'groups_series': [{
+            'name': 'my_group',
+            'count': 100,
+            'timeseries': [
+                {
+                    '@timestamp': timestamp,
+                    'count': 50,
+                    'quantiles': {},
+                    'value': 10.5
+                }
+            ]
+        }]
+    }
+    mock_bronto_client.search_post.return_value = mock_response
+
+    metrics = bronto_tools.compute_metrics(
+        log_ids=["test_log_id"],
+        metric_functions=["SUM"],
+        timerange_start=int(time.time()) * 1000,
+        timerange_end=int(time.time()) * 1000,
+        group_by_keys=['some_key']
+    )
+
+    groups = list(metrics.keys())
+    assert len(groups) == 1
+    assert groups[0] == 'my_group'
+    group = metrics[groups[0]]
+    assert isinstance(group, Timeseries)
+    assert group.count == 100
+    assert len(group.timeseries) == 1
+    assert group.timeseries[0] == Datapoint(timestamp=timestamp, count=50, quantiles={}, value=10.5)


### PR DESCRIPTION
Refactoring tools into a class helps with only creating a config and bronto client object at startup rather than for each request.

Error handling is based on raising exceptions as described at https://github.com/jlowin/fastmcp/blob/main/docs/servers/tools.mdx#error-handling

The compute_metrics tools currently support 0 or 1 group. It will be extended in a further release.

This change also removes unused functions.